### PR TITLE
Update ClientSide.java

### DIFF
--- a/ClientSide.java
+++ b/ClientSide.java
@@ -1,5 +1,6 @@
 // CLIENT SIDE implementation of two part client server TCP packet receiver
 // program author Isaac
+//re-edit for depreciation removal
 package localTalk;
 
 //Import java io and java net packages, all attributes 
@@ -10,17 +11,21 @@ import java.net.*;
 public class ClientSide {
 	// three attributes set too null data,  
 	private Socket socket = null; // JAVA NET socket stream
-	private DataInputStream data_input = null; // JAVA IO stream
+	//private DataInputStream data_input = null; // JAVA IO stream DEPRECEATED 
+	private BufferedReader data_input_new = null; // JAVA IO Buffered Reader to replace depreceated datainput stream
 	private DataOutputStream data_output = null; // JAVA IO stream
 	
-	@SuppressWarnings("deprecation") // current warning is set in place for deprecation for data_input readline. 
+	// NO LONGER REQUIRED< DEPRECIATION REMOVED @SuppressWarnings("deprecation") // current warning is set in place for deprecation for data_input readline. 
 	public ClientSide(String address, int port) // Constructor for Clientside, adding address and port
 	{
 		try { // try, except catch included
 			socket = new Socket(address, port); // inits socket with address and port
 			System.out.println("Socket Connected"); // lets user know socket connected 
 			
-			data_input = new DataInputStream(System.in); // allows system input through the datainput stream
+			//data_input = new DataInputStream(System.in); // allows system input through the datainput stream
+			data_input_new
+				= new BufferedReader (new InputStreamReader(System.in));// Buffered reader for reading the input from the client.
+
 			
 			data_output = new DataOutputStream( // creates dataoutput stream
 					socket.getOutputStream());
@@ -37,8 +42,8 @@ public class ClientSide {
 		while(!line.equals("end")) { // while program runs, read for line end, when found it will initalize a TCP flag FIN
 			// THIS WILL GRACEFULY EXIT PROGRAM, no RST handle used.
 			try {
-				line = data_input.readLine(); //deprecated read line function
-				
+				//line = data_input.readLine(); //deprecated read line function
+				line = data_input_new.readLine(); // New datainput readline to replace old datainput
 				data_output.writeUTF(line); // UTF output
 			}
 			catch(IOException i){ // catching errors due to IOExec
@@ -46,7 +51,8 @@ public class ClientSide {
 			}
 		}
 		try {
-			data_input.close(); // closes all sockets on error handle or RST TMP
+			data_input_new.close(); // Closes all sockets on error handle or RST TMP with new BufferedRead
+			//data_input.close(); // closes all sockets on error handle or RST TMP
 			data_output.close();
 			socket.close();
 			


### PR DESCRIPTION
Changing of old deprecated DataInput read to BufferedReader, removing deprecation error 

Reason for DEP- Readline Deprecated. 
This method does not properly convert bytes to characters. As of JDK 1.1, the preferred way to read lines of text is via the BufferedReader.readLine() method. Programs that use the DataInputStream class to read lines can be converted to use the BufferedReader class by replacing code of the form: 